### PR TITLE
export options merge feedback addressed

### DIFF
--- a/app/assets/stylesheets/assessments/export.css
+++ b/app/assets/stylesheets/assessments/export.css
@@ -1,0 +1,12 @@
+.button_to{
+	display: inline-block;
+}
+h2{
+	text-align: center;
+}
+.action_buttons{
+	text-align: center;
+}
+#footer{
+	text-align: center;
+}

--- a/app/views/assessments/export.html.erb
+++ b/app/views/assessments/export.html.erb
@@ -1,0 +1,17 @@
+<% @title = "Export" %>
+ <%= stylesheet_link_tag 'assessments/export' %>
+<h2 id="exportHeading">Export Options For <%= link_to @assessment.display_name, course_assessment_path(@course, @assessment) %></h2>
+<div class="action_buttons">
+<%= button_to "Export Autograder Files", export_course_assessment_path,
+{ method: :post, params: {:files_wanted => "autograde"},
+ :class=>(@assessment.has_autograder?) ? "btn primary": "btn disabled"} %>
+ <%= button_to "Export Student Submissions", export_course_assessment_path,
+{ method: :post, params: {:files_wanted => "handin"},
+ :class=>"btn primary"} %>
+ <%= button_to "Export Everything", export_course_assessment_path,
+{ method: :post, params: {:files_wanted => "everything"},
+ :class=>"btn primary"} %>
+</div>
+
+
+

--- a/app/views/assessments/show.html.erb
+++ b/app/views/assessments/show.html.erb
@@ -40,6 +40,7 @@
             <ul class="options">
               <li> <%= link_to "Edit assessment", {:action => "edit" }, {:title=> "View and modify the properties for this assessment, including its problems", :class=>""} %></li>
               <li> <%= link_to "Grade submissions", {:action => "viewGradesheet" }, {:title=> "View and enter grades on the gradesheet" } %></li>
+              <li> <%= link_to "Export Options", {:action => "export" }, {:title=> "View options for exporting different parts of this assignment." } %></li>
               </li>
               <% if @assessment.has_svn then %>
                 <li><%= link_to "SVN settings", [:admin_svn, @course, @assessment], title: "Manage the SVN repositories" %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,7 @@ Autolab3::Application.routes.draw do
         get "statistics"
         get "withdrawAllGrades"
         get "export"
+        post "export"
         patch "edit/*active_tab", action: :update
         get "edit/*active_tab", action: :edit
         post "handin"


### PR DESCRIPTION
added back in export ability as well as added different options for profs to choose.
export everything - entire assignment dir.
export students files - handin directory not including the deleted submissions.
export autograde files - exports the autograder files.

right now perms for this are instructor or above we can change later if TA's need this.

addressed feedback from the last pr #36 